### PR TITLE
Fix passing multiple chromium args

### DIFF
--- a/packages/haxroomie-core/src/Haxroomie.js
+++ b/packages/haxroomie-core/src/Haxroomie.js
@@ -55,7 +55,7 @@ class Haxroomie extends EventEmitter {
    * @param {string} [options.executablePath] - Path to chrome launcher.
    * @param {string} [options.downloadDirectory] - Directory to where the files
    *    downloaded from the browser are saved.
-   * @param {string} [options.chromiumArgs] - Additional arguments for the
+   * @param {array} [options.chromiumArgs] - Additional arguments for the
    *    chromium browser.
    */
   constructor({
@@ -118,7 +118,7 @@ class Haxroomie extends EventEmitter {
     }
 
     if (this.chromiumArgs) {
-      browserArgs.push(this.chromiumArgs);
+      browserArgs.push(...this.chromiumArgs);
     }
 
     let launchOptions = {


### PR DESCRIPTION
### Issue
I was not able to run haxroomie with an array of additional flags for chromium - they were not passed through. 

### Necessity
Additional flags are being used by HaxBall room creators to optimize browser usage.

### Description
Current version might suggest, that we would be able to pass multiple flags by adding "one string", but through debugging neither was I not able to achieve that, nor it is aligned with [Puppeteer docs](https://github.com/puppeteer/puppeteer/blob/main/docs/api.md#puppeteerdefaultargsoptions).

After fix, it is possible to add multiple flags like so (example):

```
haxroomie-cli -c config.js --no-sandbox \
-a="--disable-dev-shm-usage" \
-a="--renderer-process-limit=64" \
-a="--enable-low-res-tiling" \
-a="--enable-native-gpu-memory-buffers" \
-a="--webrtc-max-cpu-consumption-percentage=100" \
-a="--disable-webrtc-encryption" \
-a="--unlimited-storage" \
-a='--disable-infobars' \
-a='--single-process' \
-a='--no-zygote' \
-a='--no-first-run' \
-a='--ignore-certificate-errors' \
-a='--ignore-certificate-errors-skip-list' \
-a='--disable-dev-shm-usage' \
-a='--disable-accelerated-2d-canvas' \
-a='--disable-gpu' \
-a='--hide-scrollbars' \
-a='--disable-notifications' \
-a='--disable-background-timer-throttling' \
-a='--disable-backgrounding-occluded-windows' \
-a='--disable-breakpad' \
-a='--disable-component-extensions-with-background-pages' \
-a='--disable-extensions' \
-a='--disable-features=TranslateUI,BlinkGenPropertyTrees' \
-a='--disable-ipc-flooding-protection' \
-a='--disable-renderer-backgrounding' \
-a='--enable-features=NetworkService,NetworkServiceInProcess' \
-a='--force-color-profile=srgb' \
-a='--metrics-recording-only' \
-a='--mute-audio'
```